### PR TITLE
Get-FileLockProcess: Add support for PS 7.0

### DIFF
--- a/MyFunctions/PowerShellCore_Compatible/Get-FileLockProcess.ps1
+++ b/MyFunctions/PowerShellCore_Compatible/Get-FileLockProcess.ps1
@@ -69,7 +69,9 @@ function Get-FileLockProcess {
             $_.GetName().Name -eq "mscorlib" -or
             $_.GetName().Name -eq "System" -or
             $_.GetName().Name -eq "System.Collections" -or
+            $_.GetName().Name -eq "System.ComponentModel.Primitives" -or
             $_.GetName().Name -eq "System.Core" -or
+            $_.GetName().Name -eq "System.Diagnostics.Process" -or
             $_.GetName().Name -eq "System.IO" -or
             $_.GetName().Name -eq "System.Linq" -or
             $_.GetName().Name -eq "System.Runtime" -or


### PR DESCRIPTION
Support PowerShell 7.0 (and above?) in `Get-FileLockProcess`.

### Issue
Trying to run current `Get-FileLockProcess` on PS 7.0.4 throws the following:

<details><summary>PowerShell 7.0.4 output</summary>

```
Add-Type:
Line |
 200 |              Add-Type -ReferencedAssemblies $ReferencedAssemblies -Typ …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | (87,36): error CS1069: The type name 'Process' could not be found in the namespace 'System.Diagnostics'. This type has been forwarded to assembly 'System.Diagnostics.Process, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' Consider adding a reference to that assembly.
                static public List<Process> WhoIsLocking(string path)
                                   ^

Add-Type:
Line |
 200 |              Add-Type -ReferencedAssemblies $ReferencedAssemblies -Typ …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | (91,26): error CS1069: The type name 'Process' could not be found in the namespace 'System.Diagnostics'. This type has been forwarded to assembly 'System.Diagnostics.Process, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' Consider adding a reference to that assembly.
                    List<Process> processes = new List<Process>();
                         ^

Add-Type:
Line |
 200 |              Add-Type -ReferencedAssemblies $ReferencedAssemblies -Typ …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | (91,56): error CS1069: The type name 'Process' could not be found in the namespace 'System.Diagnostics'. This type has been forwarded to assembly 'System.Diagnostics.Process, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' Consider adding a reference to that assembly.
                    List<Process> processes = new List<Process>();
                                                       ^

Add-Type:
Line |
 200 |              Add-Type -ReferencedAssemblies $ReferencedAssemblies -Typ …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | (124,54): error CS1069: The type name 'Process' could not be found in the namespace 'System.Diagnostics'. This type has been forwarded to assembly 'System.Diagnostics.Process, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' Consider adding a reference to that assembly.
                                processes = new List<Process>((int)pnProcInfo);
                                                     ^

Add-Type:
Line |
 200 |              Add-Type -ReferencedAssemblies $ReferencedAssemblies -Typ …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | (132,55): error CS0103: The name 'Process' does not exist in the current context
                                        processes.Add(Process.GetProcessById(processInfo[i].Process.dwProcessId));
                                                      ^

Add-Type:
Line |
 200 |              Add-Type -ReferencedAssemblies $ReferencedAssemblies -Typ …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot add type. Compilation errors occurred.
InvalidOperation:
Line |
 206 |          $Result = [MyCore.Utils.FileLockUtil]::WhoIsLocking($FilePath …
     |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Unable to find type [MyCore.Utils.FileLockUtil].
```

</summary>